### PR TITLE
Job Restart #14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 - Kernel Dispatch #13
+- Job Restart #14
+    - New commands: `job:restart` `job:stop` and `job:reset`
+    - Cache integration
 
 ## [0.3.2] - 2017-03-30
 

--- a/README.md
+++ b/README.md
@@ -123,6 +123,23 @@ In order to start consuming jobs, you need to do a few things:
 
     You can change the verbosity level to suite your needs
 
+### Restarting & Stopping Jobs
+
+There are times when you want to restart the running consumer or even restart the system. To enable this, you need to integrate `Psr\SimpleCache` into the kernel.
+
+Enabling cache:
+
+```php
+<?php
+
+$kernel['Psr\SimpleCache\CacheInterface'] = function($c) {
+    // return any CacheInterface
+    return new Symfony\Component\Cache\Simple\RedisCache($c['Predis\ClientInterface']);
+};
+```
+
+Once cache is enabled, then you'll have access to the following commands: `job:stop`, `job:restart`, and `job:reset`.
+
 ## Concepts
 
 The Job library is broken up into several parts: The Kernel, ScheduleLoop, Queues, Dispatch, Console, Pipeline, Jobs

--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
         "krak/mw": "^0.5.0",
         "nikic/iter": "^1.4",
         "psr/log": "^1.0",
+        "psr/simple-cache": "^1.0",
         "symfony/filesystem": "^3.2",
         "symfony/process": "^2.8|^3.0"
     },
@@ -32,7 +33,7 @@
         "peridot-php/peridot": "^1.18",
         "pimple/pimple": "^3.0",
         "predis/predis": "^1.1",
-        "skyzyx/monolog-json-pretty-print-formatter": "^1.0",
+        "symfony/cache": "^3.3",
         "symfony/console": "^3.2",
         "symfony/var-dumper": "^3.2"
     },

--- a/src/Console/ConsumeCommand.php
+++ b/src/Console/ConsumeCommand.php
@@ -30,11 +30,15 @@ class ConsumeCommand extends Command
             return 0;
         }
         $options = $this->getHelper('krak_job')->getKernel()['krak.job.config'];
+        $options['_instance_name'] = $instance_name;
 
-        $bin = $this->getBinFromArgv($_SERVER['argv']);
-        $options['worker_cmd'] = $bin . ' job:worker ' .$this->getVerbosityString($output);
-        $options['scheduler_cmd'] = $bin . ' job:scheduler ' . $this->getVerbosityString($output);
+        $argv = $_SERVER['argv'];
+        $bin = $this->getBinFromArgv($argv);
 
+        $options['_worker_cmd'] = $bin . ' job:worker ' . $this->getVerbosityString($output);
+        $options['_scheduler_cmd'] = $bin . ' job:scheduler ' . $this->getVerbosityString($output);
+        $options['_consume_cmd'] = $bin . ' ' . implode(' ', array_slice($argv, 1));
+        $options['_root'] = true;
         $command = $this->getApplication()->find('job:scheduler');
         $command->run($this->createSchedulerInput($options), $output);
     }

--- a/src/Console/ResetCommand.php
+++ b/src/Console/ResetCommand.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Krak\Job\Console;
+
+use Krak\Job,
+    Symfony\Component\Console\Command\Command,
+    Symfony\Component\Console\Input,
+    Symfony\Component\Console\Output,
+    Symfony\Component\Console\Logger\ConsoleLogger;
+use Symfony\Component\Filesystem\LockHandler;
+
+class ResetCommand extends Command
+{
+    protected function configure() {
+        $this->setName('job:reset')
+            ->setDescription('Resets the scheduler cache.')
+            ->addArgument(
+                'instance-name',
+                Input\InputArgument::OPTIONAL,
+                'An identifier for the scheduler instance. Defaults to "scheduler"'
+            );
+    }
+
+    protected function execute(Input\InputInterface $input, Output\OutputInterface $output) {
+        $instance_name = $input->getArgument('instance-name') ?: 'scheduler';
+
+        $kernel = $this->getHelper('krak_job')->getKernel();
+        if (!$kernel->isCacheEnabled()) {
+            $output->writeln('<error>Cannot reset scheduler cache without cache enabled.</error>');
+            return;
+        }
+
+        $scheduler_control = $kernel[Job\SchedulerControl::class];
+        $scheduler_control->resetSchedulerCache($instance_name, new ConsoleLogger($output));
+    }
+}

--- a/src/Console/RestartCommand.php
+++ b/src/Console/RestartCommand.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Krak\Job\Console;
+
+use Krak\Job,
+    Symfony\Component\Console\Command\Command,
+    Symfony\Component\Console\Input,
+    Symfony\Component\Console\Output,
+    Symfony\Component\Console\Logger\ConsoleLogger;
+use Symfony\Component\Filesystem\LockHandler;
+
+class RestartCommand extends Command
+{
+    protected function configure() {
+        $this->setName('job:restart')
+            ->setDescription('Restarts a running scheduler.')
+            ->addArgument(
+                'instance-name',
+                Input\InputArgument::OPTIONAL,
+                'An identifier for the scheduler instance. Defaults to "scheduler"'
+            );
+    }
+
+    protected function execute(Input\InputInterface $input, Output\OutputInterface $output) {
+        $instance_name = $input->getArgument('instance-name') ?: 'scheduler';
+
+        $kernel = $this->getHelper('krak_job')->getKernel();
+        if (!$kernel->isCacheEnabled()) {
+            $output->writeln('<error>Cannot restart a scheduler without cache enabled.</error>');
+            return;
+        }
+
+        $scheduler_control = $kernel[Job\SchedulerControl::class];
+        $scheduler_control->restartScheduler($instance_name, new ConsoleLogger($output));
+    }
+}

--- a/src/Console/StopCommand.php
+++ b/src/Console/StopCommand.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Krak\Job\Console;
+
+use Krak\Job,
+    Symfony\Component\Console\Command\Command,
+    Symfony\Component\Console\Input,
+    Symfony\Component\Console\Output,
+    Symfony\Component\Console\Logger\ConsoleLogger;
+use Symfony\Component\Filesystem\LockHandler;
+
+class StopCommand extends Command
+{
+    protected function configure() {
+        $this->setName('job:stop')
+            ->setDescription('Stops a running scheduler.')
+            ->addArgument(
+                'instance-name',
+                Input\InputArgument::OPTIONAL,
+                'An identifier for the scheduler instance. Defaults to "scheduler"'
+            );
+    }
+
+    protected function execute(Input\InputInterface $input, Output\OutputInterface $output) {
+        $instance_name = $input->getArgument('instance-name') ?: 'scheduler';
+
+        $kernel = $this->getHelper('krak_job')->getKernel();
+        if (!$kernel->isCacheEnabled()) {
+            $output->writeln('<error>Cannot stop a scheduler without cache enabled.</error>');
+            return;
+        }
+
+        $scheduler_control = $kernel[Job\SchedulerControl::class];
+        $scheduler_control->stopScheduler($instance_name, new ConsoleLogger($output));
+    }
+}

--- a/src/JobServiceProvider.php
+++ b/src/JobServiceProvider.php
@@ -5,6 +5,7 @@ namespace Krak\Job;
 use Krak\Cargo;
 use Krak\Mw;
 use Krak\AutoArgs;
+use Psr\SimpleCache\CacheInterface;
 
 class JobServiceProvider implements Cargo\ServiceProvider
 {
@@ -44,8 +45,12 @@ class JobServiceProvider implements Cargo\ServiceProvider
                 Mw\compose([
                     Mw\guard('No schedulerLoop was able to resolve a response. Please check your configuration.'),
                     $loop
-                ])
+                ]),
+                $c->has(CacheInterface::class) ? $c->get(CacheInterface::class) : null
             );
+        };
+        $c[SchedulerControl::class] = function($c) {
+            return new SchedulerControl($c[CacheInterface::class]);
         };
         $c[Worker::class] = function($c) {
             $consume = $c['krak.job.pipeline.consume'];

--- a/src/Kernel.php
+++ b/src/Kernel.php
@@ -3,6 +3,7 @@
 namespace Krak\Job;
 
 use Krak\Cargo;
+use Psr\SimpleCache\CacheInterface;
 
 class Kernel extends Cargo\Container\ContainerDecorator implements Queue\QueueManager
 {
@@ -37,5 +38,9 @@ class Kernel extends Cargo\Container\ContainerDecorator implements Queue\QueueMa
 
     public function getQueue($name) {
         return $this[Queue\QueueManager::class]->getQueue($name);
+    }
+
+    public function isCacheEnabled() {
+        return $this->has(CacheInterface::class);
     }
 }

--- a/src/ScheduleLoop/ScheduleLoopParams.php
+++ b/src/ScheduleLoop/ScheduleLoopParams.php
@@ -5,6 +5,7 @@ namespace Krak\Job\ScheduleLoop;
 class ScheduleLoopParams {
     public $queue_manager;
     public $process_manager;
+    public $cache;
     public $logger;
     public $iteration_count;
     public $options;
@@ -12,12 +13,30 @@ class ScheduleLoopParams {
     public function has($key) {
         return array_key_exists($key, $this->options);
     }
+
     public function get($key, $default = null) {
         if (!$this->has($key)) {
             return $default;
         }
 
         return $this->options[$key];
+    }
+
+    /** retrieves the instance name from the options */
+    public function getInstanceName() {
+        return $this->get('_instance_name');
+    }
+
+    public function getWorkerCommand() {
+        return $this->get('_worker_cmd');
+    }
+
+    public function getSchedulerCommand() {
+        return $this->get('_scheduler_cmd');
+    }
+
+    public function buildCacheKey($key) {
+        return $this->getInstanceName() . '_' . $key;
     }
 
     /** returns a queue instance from the queue manager based off of the queue

--- a/src/ScheduleLoop/loop.php
+++ b/src/ScheduleLoop/loop.php
@@ -88,3 +88,20 @@ function ttlScheduleLoop() {
         return $next($params);
     };
 }
+
+/** Checks the cache if the restart flag is set and triggers kill */
+function killFromCacheScheduleLoop() {
+    return function($params, $next) {
+        if (!$params->cache || $params->get('kill')) {
+            return $next($params);
+        }
+
+
+        if ($params->cache->get('kill', false)) {
+            $params->logger->debug('Received kill from cache, sending kill');
+            $params->options['kill'] = true;
+        }
+
+        return $next($params);
+    };
+}

--- a/src/ScheduleLoop/scheduler.php
+++ b/src/ScheduleLoop/scheduler.php
@@ -12,6 +12,7 @@ function schedulerScheduleLoop($loop = null) {
         schedulerLogScheduleLoop(),
         statsLogScheduleLoop(),
         ttlScheduleLoop(),
+        killFromCacheScheduleLoop(),
     ]);
     return function($params, $next) use ($loop) {
         if (!$params->has('schedulers')) {
@@ -39,7 +40,7 @@ function schedulerDispatchScheduleLoop() {
             $options = $options + $popts;
 
             $params->process_manager->launch(
-                $params->get('scheduler_cmd'),
+                $params->getSchedulerCommand(),
                 json_encode($options),
                 $options
             );

--- a/src/Scheduler.php
+++ b/src/Scheduler.php
@@ -2,10 +2,11 @@
 
 namespace Krak\Job;
 
-use Psr\Log\LoggerInterface,
-    iter,
-    Symfony\Component\Console\Output\OutputInterface,
-    Symfony\Component\Process;
+use Psr\Log\LoggerInterface;
+use Psr\SimpleCache\CacheInterface;
+use iter;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Process;
 
 use function Krak\Mw\compose;
 
@@ -14,11 +15,13 @@ class Scheduler
     private $process_manager;
     private $queue_manager;
     private $loop;
+    private $cache;
 
-    public function __construct(ProcessManager\ProcessManager $process_manager, Queue\QueueManager $queue_manager, $loop) {
+    public function __construct(ProcessManager\ProcessManager $process_manager, Queue\QueueManager $queue_manager, $loop, CacheInterface $cache = null) {
         $this->process_manager = $process_manager;
         $this->queue_manager = $queue_manager;
         $this->loop = $loop;
+        $this->cache = $cache;
     }
 
     public function run(OutputInterface $output, LoggerInterface $logger, array $options) {
@@ -29,15 +32,45 @@ class Scheduler
         $params->queue_manager = new Queue\CachedQueueManager($this->queue_manager);
         $params->logger = $logger;
         $params->output = $output;
-
         $params->options = $options;
         $params->iteration_count = $i;
 
+        $params->cache = SimpleCache\PrefixCache::wrapInstanceName(
+            $params->getInstanceName(),
+            $this->cache
+        );
+
         $loop = $this->loop;
+
+        $is_root = $params->get('_root', false);
+        if ($is_root) {
+            unset($params->options['_root']);
+            if ($params->cache) {
+                $this->initializeCache($params);
+            }
+        }
 
         while($loop($params)) {
             $i += 1;
             $params->iteration_count = $i;
         }
+
+        if ($is_root) {
+            if ($params->cache) {
+                $stats = $params->cache->get('scheduler_stats');
+                $stats['running'] = false;
+                $stats['end'] = time();
+                $params->cache->set('scheduler_stats', $stats);
+            }
+        }
+    }
+
+    private function initializeCache($params) {
+        $params->cache->set('scheduler_stats', [
+            'running' => true,
+            'start' => time(),
+        ]);
+        $params->cache->set('scheduler_options', $params->options);
+        $params->cache->set('kill', false);
     }
 }

--- a/src/SchedulerControl.php
+++ b/src/SchedulerControl.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Krak\Job;
+
+use Psr\SimpleCache\CacheInterface;
+use Psr\Log;
+use Symfony\Component\Process;
+
+/** Manages a running scheduler via the cache */
+class SchedulerControl
+{
+    private $cache;
+
+    public function __construct(CacheInterface $cache) {
+        $this->cache = $cache;
+    }
+
+    public function restartScheduler($name, Log\LoggerInterface $logger = null) {
+        $logger = $logger ?: new Log\NullLogger();
+        $cache = SimpleCache\PrefixCache::wrapInstanceName($name, $this->cache);
+
+        $this->stopScheduler($name, $logger);
+
+        $options = $cache->get('scheduler_options');
+        if (!$options) {
+            $logger->notice("Cannot restart scheduler that never ran.");
+            return;
+        }
+
+        $logger->info("Starting scheduler.");
+        $logger->debug('Consume command: ' . $options['_consume_cmd']);
+
+        $options['_root'] = true;
+
+        $proc = new Process\Process($options['_consume_cmd']);
+        $proc->setInput(json_encode($options));
+        $proc->start();
+
+        do {
+            $logger->info("Waiting for scheduler to start up...");
+            sleep(2);
+            $stats = $cache->get('scheduler_stats');
+        } while (!$stats['running']);
+
+        $logger->info("Scheduler is running.");
+    }
+
+    public function stopScheduler($name, Log\LoggerInterface $logger = null) {
+        $logger = $logger ?: new Log\NullLogger();
+        $cache = SimpleCache\PrefixCache::wrapInstanceName($name, $this->cache);
+
+        $stats = $cache->get('scheduler_stats');
+        if (!$stats || !$stats['running']) {
+            $logger->notice('Scheduler is not running.');
+            return;
+        }
+
+        $logger->info('Killing scheduler');
+        $cache->set('kill', true);
+
+        do {
+            $logger->info("Waiting for scheduler to stop...");
+            sleep(2);
+            $stats = $cache->get('scheduler_stats');
+        } while ($stats['running']);
+
+        $duration = ScheduleLoop\_formatSeconds($stats['end'] - $stats['start']);
+        $logger->info("Scheduler stopped after " . $duration . '.');
+    }
+
+    public function resetSchedulerCache($name, Log\LoggerInterface $logger = null) {
+        $logger = $logger ?: new Log\NullLogger();
+        $cache = SimpleCache\PrefixCache::wrapInstanceName($name, $this->cache);
+
+        $logger->info("Resetting scheduler cache.");
+
+        $cache->deleteMultiple([
+            'scheduler_stats',
+            'scheduler_options',
+            'kill'
+        ]);
+    }
+}

--- a/src/SimpleCache/PrefixCache.php
+++ b/src/SimpleCache/PrefixCache.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Krak\Job\SimpleCache;
+
+use Psr\SimpleCache\CacheInterface;
+use iter;
+
+class PrefixCache implements CacheInterface
+{
+    private $cache;
+    private $prefix;
+
+    public function __construct(CacheInterface $cache, $prefix) {
+        $this->cache = $cache;
+        $this->prefix = $prefix;
+    }
+
+    public function get($key, $default = null) {
+        return $this->cache->get($this->prefix.$key, $default);
+    }
+    public function set($key, $value, $ttl = null) {
+        return $this->cache->set($this->prefix.$key, $value, $ttl);
+    }
+    public function delete($key) {
+        return $this->cache->delete($this->prefix.$key);
+    }
+    public function clear() {
+        return $this->clear();
+    }
+    public function getMultiple($keys, $default = null) {
+        return $this->cache->getMultiple(iter\map($this->mapKey(), $keys), $default);
+    }
+    public function setMultiple($values, $ttl = null) {
+        return $this->cache->setMultiple(iter\mapKeys($this->mapKey(), $values), $ttl);
+    }
+    public function deleteMultiple($keys) {
+        return $this->cache->deleteMultiple(iter\map($this->mapKey(), $keys));
+    }
+    public function has($key) {
+        return $this->cache->has($this->prefix.$key);
+    }
+
+    private function mapKey() {
+        return function($key) {
+            return $this->prefix.$key;
+        };
+    }
+
+    public static function wrapInstanceName($instance_name, CacheInterface $cache = null) {
+        if (!$cache) {
+            return;
+        }
+
+        return new self($cache, 'krak_job_' . $instance_name . '_');
+    }
+}

--- a/src/job.php
+++ b/src/job.php
@@ -38,5 +38,12 @@ function registerConsole(\Symfony\Component\Console\Application $app, Kernel $ke
         new Console\SchedulerCommand(),
         new Console\WorkerCommand(),
     ]);
+    if ($kernel->isCacheEnabled()) {
+        $app->addCommands([
+            new Console\RestartCommand(),
+            new Console\StopCommand(),
+            new Console\ResetCommand(),
+        ]);
+    }
     $app->getHelperSet()->set(new Console\JobHelper($kernel));
 }

--- a/test/functional/kernel.php
+++ b/test/functional/kernel.php
@@ -12,8 +12,13 @@ $kernel['Aws\Sqs\SqsClient'] = function() {
         'region' => 'us-west-1',
     ]);
 };
-$kernel['krak.job.queue_provider'] = 'sqs';
-$kernel['krak.job.queue.sqs.receive_options'] = ['MaxNumberOfMessages' => 5];
+$kernel['krak.job.queue_provider'] = 'redis';
+$kernel['Psr\SimpleCache\CacheInterface'] = function($c) {
+    return new Symfony\Component\Cache\Simple\RedisCache(
+        $c['Predis\ClientInterface']
+    );
+};
+// $kernel['krak.job.queue.sqs.receive_options'] = ['MaxNumberOfMessages' => 5];
 $kernel[SplStack::class] = function() {
     $s = new SplStack();
     $s->push(1);
@@ -23,9 +28,24 @@ $kernel[SplStack::class] = function() {
     return $s;
 };
 $kernel->config([
-    'queue' => 'jobs1',
+    'name' => 'Test Scheduler',
+    'schedulers' => [
+        [
+            'queue' => 'jobs1',
+            'sleep' => 2,
+        ],
+        [
+            'schedulers' => [
+                ['queue' => 'jobs2'],
+                ['queue' => 'jobs3']
+            ],
+            'sleep' => 5,
+        ]
+    ],
     'sleep' => 2,
-    'ttl' => 50,
+    // 'ttl' => 50,
 ]);
+
+// $kernel['Psr\SimpleCache\CacheInterface']->clear();
 
 return $kernel;


### PR DESCRIPTION
- Adding ability to restart/stop running schedulers
- Schedulers now can utilize a cache to post and receive
  information
- Added new kill from cache scheduleLoop

Signed-off-by: RJ Garcia <rj@bighead.net>