### PR TITLE
Doctrine Queue #12

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /vendor/
 /composer.lock
 /playground.php
+/test/functional/jobs.db

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Added
 
 - Synchronous Queue Support #11
+- Doctrine Queue Support #12
+- WrappedJob Helper methods
 
 ## 0.3.4 - 2017-06-03
 

--- a/README.md
+++ b/README.md
@@ -180,10 +180,54 @@ The Queuing module handles the actual queueing implementations. There are two ma
 
 **Supported Queues**
 
+- Doctrine
 - Redis
 - Sqs
 - Stub
 - Sync
+
+#### Doctrine
+
+Doctrine requires the `doctrine/dbal` library to be installed.
+
+```php
+$kernel['Doctrine\DBAL\Connection'] = function() {
+    return Doctrine\DBAL\DriverManager::getConnection([
+        /* connection params */
+    ]);
+};
+$kernel['krak.job.queue_provider'] = 'doctrine';
+$kernel['krak.job.queue.doctrine.table_name'] = 'krak_jobs';
+```
+
+Once that's setup, you'll need to perform the database migration to initialize the jobs table. The `Krak\Job\Queue\Doctrine\JobMigration` class is a utility that will facilitate running the migration.
+
+If you already using Doctrine Migrations in your project, you can use simply use the following methods:
+
+```php
+// in your migration class
+public function up(Schema $schema) {
+    $migration = new Krak\Job\Queue\Doctrine\JobMigration('krak_jobs');
+    $migration->up($schema);
+}
+
+public function down(Schema $schema) {
+    $migration = new Krak\Job\Queue\Doctrine\JobMigration('krak_jobs');
+    $migration->down($schema);
+}
+```
+
+Also, you can simply run the following php code to migrate your table up or down
+
+```php
+$conn = $kernel['Doctrine\DBAL\Connection'];
+$migration = $kernel['Krak\Job\Queue\Doctrine\JobMigration'];
+
+// up
+$migration->migrateUp($conn);
+// or down
+// $migration->migrateDown($conn);
+```
 
 #### Redis
 

--- a/composer.json
+++ b/composer.json
@@ -32,6 +32,7 @@
     },
     "require-dev": {
         "aws/aws-sdk-php": "^3.24",
+        "doctrine/dbal": "^2.5",
         "krak/php-inc": "^0.1.3",
         "mockery/mockery": "^1.0-alpha",
         "monolog/monolog": "^1.22",
@@ -42,8 +43,9 @@
         "symfony/console": "^3.2",
         "symfony/var-dumper": "^3.2"
     },
-    "suggests": {
+    "suggest": {
         "predis/predis": "Enables redis queues",
-        "aws/aws-sdk-php": "Enables SQS queues"
+        "aws/aws-sdk-php": "Enables SQS queues",
+        "doctrine/dbal": "Enables Doctrine queues"
     }
 }

--- a/src/Queue/Doctrine/DoctrineQueue.php
+++ b/src/Queue/Doctrine/DoctrineQueue.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Krak\Job\Queue\Doctrine;
+
+use Krak\Job;
+
+class DoctrineQueue extends Job\Queue\AbstractQueue
+{
+    private $repo;
+    private $cached_jobs;
+
+    public function __construct($name, JobRepository $repo) {
+        parent::__construct($name);
+        $this->repo = $repo;
+        $this->cached_jobs = [];
+    }
+
+    /** push a job onto the queue */
+    public function enqueue(Job\WrappedJob $job) {
+        $this->repo->addJob($job, $this->name);
+    }
+
+    /** take a job off of the queue */
+    public function dequeue() {
+        if (!count($this->cached_jobs)) {
+            $this->cached_jobs = $this->repo->getAvailableJobs($this->name);
+        }
+        if (!count($this->cached_jobs)) {
+            return;
+        }
+
+        $job_row = array_shift($this->cached_jobs);
+        $job = Job\WrappedJob::fromString($job_row['job'])->withAddedPayload([
+            '_doctrine' => ['id' => $job_row['id']]
+        ])->withQueueProvider('doctrine');
+        $this->repo->processJob($job);
+        return $job;
+    }
+
+    /** job was completed and can be removed completely from queue */
+    public function complete(Job\WrappedJob $job) {
+        $this->repo->completeJob($job);
+    }
+}

--- a/src/Queue/Doctrine/DoctrineQueueManager.php
+++ b/src/Queue/Doctrine/DoctrineQueueManager.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Krak\Job\Queue\Doctrine;
+
+use Krak\Job;
+
+class DoctrineQueueManager implements Job\Queue\QueueManager
+{
+    private $repo;
+
+    public function __construct(JobRepository $repo) {
+        $this->repo = $repo;
+    }
+
+    public function createQueue($name, array $opts = []) {
+        /* noop */
+    }
+    public function removeQueue($name) {
+        /* noop */
+    }
+    public function getQueue($name) {
+        return new DoctrineQueue($name, $this->repo);
+    }
+}

--- a/src/Queue/Doctrine/JobMigration.php
+++ b/src/Queue/Doctrine/JobMigration.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Krak\Job\Queue\Doctrine;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Connection;
+
+class JobMigration
+{
+    private $table_name;
+
+    public function __construct($table_name) {
+        $this->table_name = $table_name;
+    }
+
+    public function up(Schema $schema) {
+        $jobs = $schema->createTable($this->table_name);
+        $jobs->addColumn('id', 'integer', ['unsigned' => true, 'autoincrement' => true]);
+        $jobs->addColumn('job', 'text');
+        $jobs->addColumn('queue', 'string');
+        $jobs->addColumn('name', 'string');
+        $jobs->addColumn('status', 'string');
+        $jobs->addColumn('created_at', 'datetime');
+        $jobs->addColumn('available_at', 'datetime');
+        $jobs->addColumn('processed_at', 'datetime', ['notnull' => false]);
+        $jobs->addColumn('completed_at', 'datetime', ['notnull' => false]);
+        $jobs->addIndex(['queue', 'status'], 'queue_status_index');
+        $jobs->addIndex(['available_at'], 'available_at_index');
+        $jobs->setPrimaryKey(['id']);
+    }
+
+    public function down(Schema $schema) {
+        $schema->dropTable($this->table_name);
+    }
+
+    public function migrateUp(Connection $conn, $dry_run = false) {
+        $sm = $conn->getSchemaManager();
+        $from_schema = $sm->createSchema();
+        $to_schema = clone $from_schema;
+        $this->up($to_schema);
+        $sql = $from_schema->getMigrateToSql($to_schema, $conn->getDatabasePlatform());
+        $this->execSql($conn, $sql, $dry_run);
+    }
+
+    public function migrateDown(Connection $conn, $dry_run = false) {
+        $sm = $conn->getSchemaManager();
+        $from_schema = $sm->createSchema();
+        $to_schema = clone $from_schema;
+        $this->down($to_schema);
+        $sql = $from_schema->getMigrateToSql($to_schema, $conn->getDatabasePlatform());
+        $this->execSql($conn, $sql, $dry_run);
+    }
+
+    private function execSql($conn, $sql, $dry_run) {
+        echo "# Executing SQL\n";
+        echo implode(";\n", $sql) . ";\n";
+
+        if ($dry_run) {
+            return;
+        }
+
+        foreach ($sql as $query) {
+            $conn->query($query);
+        }
+    }
+}

--- a/src/Queue/Doctrine/JobRepository.php
+++ b/src/Queue/Doctrine/JobRepository.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace Krak\Job\Queue\Doctrine;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Types\Type;
+use Krak\Job;
+
+/** this is the main API for managing the db jobs table/data */
+class JobRepository
+{
+    const JOB_STATUS_CREATED = 'created';
+    const JOB_STATUS_PROCESSING = 'processing';
+    const JOB_STATUS_COMPLETED = 'completed';
+
+    private $conn;
+    private $table_name;
+
+    public function __construct(Connection $conn, $table_name) {
+        $this->conn = $conn;
+        $this->table_name = $table_name;
+    }
+
+    public function getJobById($id) {
+        return $this->conn->fetchAssoc(
+            "SELECT * FROM {$this->table_name} WHERE id = :id",
+            ['id' => $id]
+        );
+    }
+
+    /** add a new wrapped job */
+    public function addJob(Job\WrappedJob $job, $queue) {
+        $qb = $this->conn->createQueryBuilder();
+        $qb->insert($this->table_name);
+        $qb->values([
+            'status' => ':status',
+            'job' => ':job',
+            'name' => ':name',
+            'queue' => ':queue',
+            'created_at' => ':created_at',
+            'available_at' => ':available_at',
+        ]);
+        $qb->setParameters([
+            'status' => self::JOB_STATUS_CREATED,
+            'queue' => $queue,
+            'job' => (string) $job,
+            'name' => $job->getName(),
+        ]);
+        $qb->setParameter(':created_at', new \DateTime(), Type::DATETIME);
+        $available_at = $job->getDelay()
+            ? new \DateTime(sprintf('+%d seconds', $job->getDelay()))
+            : new \DateTime();
+        $qb->setParameter(':available_at', $available_at, Type::DATETIME);
+        $qb->execute();
+
+        return $job->withAddedPayload([
+            '_doctrine' => [
+                'id' => $this->conn->lastInsertId()
+            ]
+        ]);
+    }
+
+    /** complete job */
+    public function completeJob(Job\WrappedJob $job) {
+        $data = $job->get('_doctrine');
+        $qb = $this->conn->createQueryBuilder();
+        $qb->update($this->table_name);
+        $qb->set('status', ':status');
+        $qb->set('completed_at', ':completed_at');
+        $qb->where('id = :id');
+        $qb->setParameters([
+            'id' => $data['id'],
+            'status' => self::JOB_STATUS_COMPLETED,
+        ]);
+        $qb->setParameter('completed_at', new \DateTime(), Type::DATETIME);
+        $qb->execute();
+    }
+
+    /** process job */
+    public function processJob(Job\WrappedJob $job) {
+        $data = $job->get('_doctrine');
+        $qb = $this->conn->createQueryBuilder();
+        $qb->update($this->table_name);
+        $qb->set('status', ':status');
+        $qb->set('processed_at', ':processed_at');
+        $qb->where('id = :id');
+        $qb->setParameters([
+            'id' => $data['id'],
+            'status' => self::JOB_STATUS_PROCESSING,
+        ]);
+        $qb->setParameter('processed_at', new \DateTime(), Type::DATETIME);
+        $qb->execute();
+    }
+
+    /** get available jobs */
+    public function getAvailableJobs($queue, $max = 10) {
+        $qb = $this->conn->createQueryBuilder();
+        $qb->select('*');
+        $qb->from($this->table_name);
+        $qb->where('status = :status AND queue = :queue AND available_at <= :now');
+        $qb->orderBy('status');
+        $qb->setParameters([
+            'status' => self::JOB_STATUS_CREATED,
+            'queue' => $queue,
+        ]);
+        $qb->setParameter('now', new \DateTime(), Type::DATETIME);
+        $qb->setMaxResults($max);
+        $stmt = $qb->execute();
+        return $stmt->fetchAll(\PDO::FETCH_ASSOC);
+    }
+}

--- a/src/Queue/Redis/RedisQueue.php
+++ b/src/Queue/Redis/RedisQueue.php
@@ -34,9 +34,10 @@ class RedisQueue extends Job\Queue\AbstractQueue
         $hash = md5($job);
         $this->hashed_job_map[$hash] = $job;
         $job = Job\WrappedJob::fromString($job);
-        return $job->withAddedPayload([
-            '_job_hash' => $hash
-        ]);
+        return $job->withQueueProvider('redis')
+            ->withAddedPayload([
+                '_job_hash' => $hash
+            ]);
     }
 
     public function complete(Job\WrappedJob $job) {

--- a/src/Queue/Sync/SyncQueue.php
+++ b/src/Queue/Sync/SyncQueue.php
@@ -15,7 +15,7 @@ class SyncQueue extends Job\Queue\AbstractQueue
 
     /** push a job onto the queue */
     public function enqueue(Job\WrappedJob $job) {
-        $res = unserialize($this->worker->work((string) $job));
+        $res = unserialize($this->worker->work((string) $job->withQueueProvider('sync')));
         if ($res->isFailed()) {
             throw new \RuntimeException("Job Failed - " . json_encode($res, JSON_PRETTY_PRINT));
         }

--- a/src/WrappedJob.php
+++ b/src/WrappedJob.php
@@ -39,4 +39,44 @@ class WrappedJob
             $wrapped_job['payload']
         );
     }
+
+    public function has($key) {
+        return array_key_exists($key, $this->payload);
+    }
+
+    public function get($key, $default = null) {
+        if (!$this->has($key)) {
+            return $default;
+        }
+
+        return $this->payload[$key];
+    }
+
+    public function withName($name) {
+        return $this->withAddedPayload(['name' => $name]);
+    }
+    public function getName() {
+        return $this->get('name');
+    }
+
+    public function withQueue($name) {
+        return $this->withAddedPayload(['queue' => $name]);
+    }
+    public function getQueue() {
+        return $this->get('queue');
+    }
+
+    public function withDelay($delay) {
+        return $this->withAddedPayload(['delay' => $delay]);
+    }
+    public function getDelay() {
+        return $this->get('delay');
+    }
+
+    public function withQueueProvider($queue_provider) {
+        return $this->withAddedPayload(['queue_provider' => $queue_provider]);
+    }
+    public function getQueueProvider() {
+        return $this->get('queue_provider');
+    }
 }

--- a/test/fixtures/EchoJob.php
+++ b/test/fixtures/EchoJob.php
@@ -13,6 +13,7 @@ class EchoJob implements Job\Job
     }
 
     public function handle(SplStack $stack, Job\WrappedJob $job) {
+        sleep($this->id);
         return Job\complete([
             'id' => $this->id,
             'count' => $stack->count(),

--- a/test/functional/doctrine.php
+++ b/test/functional/doctrine.php
@@ -1,0 +1,13 @@
+<?php
+
+require_once __DIR__ . '/../../vendor/autoload.php';
+
+$kernel = require __DIR__ . '/kernel.php';
+$conn = $kernel['Doctrine\DBAL\Connection'];
+$migration = $kernel['Krak\Job\Queue\Doctrine\JobMigration'];
+
+if ($argv[1] == 'up') {
+    $migration->migrateUp($conn);
+} else {
+    $migration->migrateDown($conn);
+}

--- a/test/functional/kernel.php
+++ b/test/functional/kernel.php
@@ -12,7 +12,15 @@ $kernel['Aws\Sqs\SqsClient'] = function() {
         'region' => 'us-west-1',
     ]);
 };
-// $kernel['krak.job.queue_provider'] = 'redis';
+$kernel['Doctrine\DBAL\Connection'] = function() {
+    return Doctrine\DBAL\DriverManager::getConnection([
+        'driver' => 'pdo_sqlite',
+        'user' => 'root',
+        'password' => 'pass',
+        'path' => './jobs.db',
+    ]);
+};
+$kernel['krak.job.queue_provider'] = 'doctrine';
 $kernel['Psr\SimpleCache\CacheInterface'] = function($c) {
     return new Symfony\Component\Cache\Simple\RedisCache(
         $c['Predis\ClientInterface']


### PR DESCRIPTION
- Adding Doctrine Queue
- Adding helper methods in the WrappedJob
  for commonly used payload entries and
  updated library to utilize those instead
- EchoJob now will sleep for the id given
- Each queue now will add the queue provider
  into the dequeued job
- Added doctrine/dbal into composer suggest

Signed-off-by: RJ Garcia <rj@bighead.net>