### PR TITLE
Batched Workers #22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 - WrappedJob Helper methods
 - Job Status Command #23
 - Multiple Queue Providers #21
+- Batched Workers #22
+- Documentation on config options
 
 ## 0.3.4 - 2017-06-03
 

--- a/src/FailJob/fail-job.php
+++ b/src/FailJob/fail-job.php
@@ -5,7 +5,9 @@ namespace Krak\Job\FailJob;
 function completeFailJob() {
     return function($job, $params, $next) {
         $queue = $params->queue();
-        $params->logger->debug('Fail Job: marking as complete');
+        $params->logger->debug('Failing Job {name} and marking as complete', [
+            'name' => $job->getName()
+        ]);
         $queue->complete($job);
     };
 }
@@ -24,16 +26,16 @@ function retryFailJob() {
             : 0;
 
         if ($retry >= $max_retry) {
-            $params->logger->debug('Retry exceeded, failing job', [
-                'job' => $job->name,
+            $params->logger->debug('Retry exceeded, failing job {job}', [
+                'job' => $job->getName(),
                 'payload' => $job->payload,
                 'retry' => $retry,
                 'max_retry' => $max_retry,
             ]);
             return $next($job, $params);
         } else {
-            $params->logger->debug('Retrying Job', [
-                'job' => $job->name,
+            $params->logger->debug('Retrying Job {job}', [
+                'job' => $job->getName(),
                 'payload' => $job->payload,
                 'retry' => $retry,
                 'max_retry' => $max_retry,

--- a/src/Queue/Sync/SyncQueue.php
+++ b/src/Queue/Sync/SyncQueue.php
@@ -15,9 +15,10 @@ class SyncQueue extends Job\Queue\AbstractQueue
 
     /** push a job onto the queue */
     public function enqueue(Job\WrappedJob $job) {
-        $res = unserialize($this->worker->work((string) $job->withQueueProvider('sync')));
-        if ($res->isFailed()) {
-            throw new \RuntimeException("Job Failed - " . json_encode($res, JSON_PRETTY_PRINT));
+        $serialized = Job\serializeJobs([$job->withQueueProvider('sync')]);
+        $res = unserialize($this->worker->work($serialized));
+        if ($res[0]->isFailed()) {
+            throw new \RuntimeException("Job Failed - " . json_encode($res[0], JSON_PRETTY_PRINT));
         }
     }
     /** take a job off of the queue */

--- a/src/Worker.php
+++ b/src/Worker.php
@@ -12,8 +12,6 @@ class Worker
     }
 
     public function work($input) {
-        $consume = $this->consume;
-        $job = WrappedJob::fromString($input);
-        return serialize($consume($job));
+        return serialize(array_map($this->consume, unserializeJobs($input)));
     }
 }

--- a/src/job.php
+++ b/src/job.php
@@ -54,3 +54,13 @@ function mergeConfigOptions($parent_opts, $opts) {
     unset($parent_opts['name']);
     return $opts + $parent_opts;
 }
+
+function serializeJobs(array $jobs) {
+    return json_encode(array_map('strval', $jobs));
+}
+
+function unserializeJobs($input) {
+    return array_map(function($input) {
+        return WrappedJob::fromString($input);
+    }, json_decode($input, true));
+}

--- a/test/functional/kernel.php
+++ b/test/functional/kernel.php
@@ -44,11 +44,13 @@ $kernel->config([
             'ttl' => 10,
             'respawn' => true,
             'queue_provider' => 'doctrine',
+            'batch_size' => 10
         ],
         [
             'queue' => 'jobs2',
             'sleep' => 5,
             'queue_provider' => 'redis',
+            'batch_size' => 10,
         ]
     ],
     'sleep' => 2,


### PR DESCRIPTION
- Added batch_size to determine
  num of jobs a worker can consume
- added serializeJobs and unserializeJobs
  for workers to handle batches of jobs
  instead of individual jobs
- added docs on config options

Signed-off-by: RJ Garcia <rj@bighead.net>